### PR TITLE
Add option to show/hide entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Tap Tally is designed to present a list of what's on tap in an aesthetically pleasing manner.
 It will also (_in an upcoming release_) interface with flow meters to keep a real-time tally
-of current keg levels -- no more  dry at the worst possible moment! Finally, Tap Tally also
+of current keg levels -- no more running dry at the worst possible moment! Finally, Tap Tally also
 (_in an upcoming release_) provides provisions for keeping notes about batches for streamlined record keeping.
 
 _Tap Tally is still very much a work in progress_
@@ -21,6 +21,14 @@ an Nginx image, which also includes the static assets.
 
 ## Usage
 
+### Starting Tap Tally
+
+The `docker-compose up` command will start Tap Tally, and the app can be accessed by navigating to
+http://localhost in your browser. Depending on your network configuration, you may also be able to
+access Tap Tally from all machines on your network (by default, it is listening on port 80). 
+
+### Editing the tap list
+
 Currently, all beer/tap data are stored in `data/beers.json` (_a future release will explore alternative
 data storage methods_). This file has the following structure:
 ```json
@@ -34,7 +42,8 @@ data storage methods_). This file has the following structure:
     "brewedOn": "Jan. 1, 2020",
     "keggedOn": "Feb. 1, 2020",
     "kegNo": 1,
-    "beerDescription": "Beer description goes here"
+    "beerDescription": "Beer description goes here",
+    "visible": true
   },
   {
     "tapNo": 2,
@@ -49,9 +58,10 @@ data storage methods_). This file has the following structure:
   }
 ]
 ```
-Currently, all objects in the above array will be loaded and passed to the front-end
+All objects with `visible` set to `true` in the above array will be loaded and passed to the front-end
 for display. An example file is included in this repository: simply edit the file with
-your favorite editor, save, and then refresh the page to see your changes.
+your favorite editor, save, and then refresh the page to see your changes. You can add as many or as few
+beers as you'd like.
 
 Then, navigating to `http://localhost` (once the Docker containers are running) should
 show your tap list!

--- a/data/beers.json
+++ b/data/beers.json
@@ -8,7 +8,8 @@
     "brewedOn": "Aug. 22, 2020",
     "keggedOn": "Sep. 4, 2020",
     "kegNo": 1,
-    "beerDescription": "Beer description here."
+    "beerDescription": "Beer description here.",
+    "visible": true
   },
   {
     "tapNo": null,
@@ -41,6 +42,7 @@
     "brewedOn": "Sep. 6, 2020",
     "keggedOn": null,
     "kegNo": null,
-    "beerDescription": "Beer 4 description."
+    "beerDescription": "Beer 4 description.",
+    "visible": true
   }
 ]

--- a/tap_tally/__init__.py
+++ b/tap_tally/__init__.py
@@ -12,7 +12,8 @@ def get_tap_entries():
         beer_data = json.load(f)
     entries = []
     for entry in beer_data:
-        entries.append(entry)
+        if entry.get('visible', False):
+            entries.append(entry)
     return {
         'entries': entries
     }


### PR DESCRIPTION
Summary:

As beer lists grow, it is not necessary or desirable to show all beers in the beers.json file, yet removing that data would also not be good. This PR adds a `visible` key -- if `visible` is set to true, show the entry. Otherwise, don't show it. Also includes some README updates.